### PR TITLE
Use bind instead of passing in variables to functions on Listener

### DIFF
--- a/lib/listener.js
+++ b/lib/listener.js
@@ -16,64 +16,65 @@ Listener.prototype.startGame = function () {
 };
 
 Listener.prototype.setListeners = function () {
-  this.firing(this.player, this.projectiles);
-  this.moveRight(this.player);
-  this.moveLeft(this.player);
-  this.toggleProjectileType(this.player);
+  this.firing();
+  this.moveRight();
+  this.moveLeft();
+  this.toggleProjectileType();
 };
 
-Listener.prototype.toggleProjectileType = function (player) {
+Listener.prototype.toggleProjectileType = function () {
   this.canvas.addEventListener('keydown', function (event) {
     if (event.keyCode === 32) {
-      if (player.projectileType === 'blue') {
-        player.projectileType = 'orange';
-      } else if (player.projectileType === 'orange') {
-        player.projectileType = 'blue';
+      if (this.player.projectileType === 'blue') {
+        this.player.projectileType = 'orange';
+      } else if (this.player.projectileType === 'orange') {
+        this.player.projectileType = 'blue';
       }
     }
-  });
+  }.bind(this));
 };
 
-Listener.prototype.firing = function (player, projectiles) {
-  function createProjectile(options) {
-    if (player.projectileType === 'blue') {
-      projectiles.blue = new Projectile(options);
-    } else if (player.projectileType === 'orange'){
-      projectiles.orange = new Projectile(options);
-      projectiles.orange.image = projectiles.orange.orangeProjectileImage;
-    }
-  }
+Listener.prototype.firing = function () {
   this.canvas.addEventListener('keydown', function (event) {
     if (event.keyCode === 68) {
-      var projectile = player.fireRight();
-      if ((projectile.blue && !projectiles.blue) || (projectile.orange && !projectiles.orange)){
-        createProjectile(projectile);
+      var projectile = this.player.fireRight();
+      if ((projectile.blue && !this.projectiles.blue) || (projectile.orange && !this.projectiles.orange)){
+        this.createProjectile(projectile);
       }
     } else if (event.keyCode === 65) {
-      var projectile = player.fireLeft();
-      if ((projectile.blue && !projectiles.blue) || (projectile.orange && !projectiles.orange)){
-        createProjectile(projectile);
+      var projectile = this.player.fireLeft();
+      if ((projectile.blue && !this.projectiles.blue) || (projectile.orange && !this.projectiles.orange)){
+        this.createProjectile(projectile);
       }
     }
-  });
+  }.bind(this));
 };
 
-Listener.prototype.moveRight = function(player) {
+Listener.prototype.createProjectile = function(options) {
+  if (this.player.projectileType === 'blue') {
+    this.projectiles.blue = new Projectile(options);
+  } else if (this.player.projectileType === 'orange'){
+    this.projectiles.orange = new Projectile(options);
+    this.projectiles.orange.image = this.projectiles.orange.orangeProjectileImage;
+  }
+};
+
+Listener.prototype.moveRight = function() {
   this.canvas.addEventListener('keydown', function (event) {
     if (event.keyCode === 39) {
-      player.x = player.x + 5;
-      player.image = player.rightImage;
+      this.player.x = this.player.x + 5;
+      this.player.image = this.player.rightImage;
     }
-  });
+  }.bind(this));
 };
 
-Listener.prototype.moveLeft = function(player) {
+Listener.prototype.moveLeft = function() {
   this.canvas.addEventListener('keydown', function (event) {
     if (event.keyCode === 37) {
-      player.x = player.x - 5;
-      player.image = player.leftImage;
+      this.player.x = this.player.x - 5;
+      this.player.image = this.player.leftImage;
     }
-  });
+  }.bind(this));
 };
 
 module.exports = Listener;


### PR DESCRIPTION
- This PR refactors the `Listener` class to use bind instead of passing variables on the `Listener` class through to it's functions. There was a `createProjectile` function that was defined in the `firing` function that has been pulled out.
- The only changes were made in the `Listener` class.
- If the reviewer starts the game with `npm start` they will see that the functionality has not changed, and all the listeners work as expected.

![portal](http://g.recordit.co/1oZe6pamI8.gif)

Connects to #27.

@ToniRib: thanks for being my refactoring buddy! Take a look at the changes I made.
@tessgriffin: thanks for taking a look at this!
:sparkling_heart:
