### PR TITLE
Modify lava collision detection for level 3

### DIFF
--- a/lib/detector.js
+++ b/lib/detector.js
@@ -74,13 +74,17 @@ Detector.prototype.checkBlockBottomPlayerCollision = function (player, block) {
 };
 
 Detector.prototype.checkBlockTopPlayerCollision = function (player, block) {
-  if ((player.x >= block.x) && (player.x <= (block.x + 63))) {
+  if (block.lava) {
+    if ((player.x >= (block.x - 15)) && (player.x <= (block.x + 20))) {
+      if ((player.y >= (block.y - 64)) && (player.y <= (block.y + 32))) {
+        player.dead = true;
+      }
+    }
+  } else if ((player.x >= block.x) && (player.x <= (block.x + 63))) {
     if ((player.y >= (block.y - 63)) && (player.y < block.y)) {
       this.levelCompleteCheck(player, block);
       if (this.bothPortalsOpen() && (block.bluePortal || block.orangePortal)) {
         this.teleportPlayer(player, block);
-      } else if (block.lava) {
-        player.dead = true;
       } else {
         player.y = block.y - 64;
       }

--- a/lib/level-three-layout.js
+++ b/lib/level-three-layout.js
@@ -60,7 +60,7 @@ LevelThreeLayout.prototype.createLava = function(blocks){
 };
 
 LevelThreeLayout.prototype.addDoor = function(blocks){
-  blocks.push(new Block({x: this.xValues[8], y: this.yValues[7], image: './images/door.png', collisions: [1, 2, 4], wall: false, door: true}));
+  blocks.push(new Block({x: this.xValues[9], y: this.yValues[7], image: './images/door.png', collisions: [1, 2, 4], wall: false, door: true}));
 };
 
 LevelThreeLayout.prototype.addObstacles = function(blocks){

--- a/lib/player.js
+++ b/lib/player.js
@@ -77,7 +77,7 @@ Player.prototype.move = function () {
 };
 
 Player.prototype.hitBottom = function () {
-  var rockBottom = 640 - 64;
+  var rockBottom = 640 - 20;
   if (this.y > rockBottom) {
     this.y = rockBottom;
     this.dead = true;


### PR DESCRIPTION
Modified the collision detection for top side of block / player collision detection
to first check for a lava collision with more specific collision criteria, and then continue
onwards to the rest of the collision detection.
