### PR TITLE
Add prevent default to event listeners

### DIFF
--- a/lib/listener.js
+++ b/lib/listener.js
@@ -38,21 +38,25 @@ Listener.prototype.toggleProjectileType = function () {
 Listener.prototype.firing = function () {
   this.canvas.addEventListener('keydown', function (event) {
     if (event.keyCode === 68) {
+      event.preventDefault();
       var projectile = this.player.fireRight();
       if ((projectile.blue && !this.projectiles.blue) || (projectile.orange && !this.projectiles.orange)){
         this.createProjectile(projectile);
       }
     } else if (event.keyCode === 65) {
+      event.preventDefault();
       var projectile = this.player.fireLeft();
       if ((projectile.blue && !this.projectiles.blue) || (projectile.orange && !this.projectiles.orange)){
         this.createProjectile(projectile);
       }
     } else if (event.keyCode === 87) {
+      event.preventDefault();
       var projectile = this.player.fireUp();
       if ((projectile.blue && !this.projectiles.blue) || (projectile.orange && !this.projectiles.orange)){
         this.createProjectile(projectile);
       }
     } else if (event.keyCode === 83) {
+      event.preventDefault();
       var projectile = this.player.fireDown();
       if ((projectile.blue && !this.projectiles.blue) || (projectile.orange && !this.projectiles.orange)){
         this.createProjectile(projectile);


### PR DESCRIPTION
Add a prevent default to key event listeners. Users mentioned that some keys were either scrolling or preventing game action due to in-built browser listeners
